### PR TITLE
Added buildifier enforcement

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,3 +43,18 @@ jobs:
           e2e/test.sh --bazelrc=${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc
           --google_credentials="${{ steps.auth.outputs.credentials_file_path }}"
           --${{ matrix.bzlmod }}
+
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          clean: true
+      - name: Buildifier
+        run: |
+          wget "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDIFIER_VERSION}/buildifier-linux-amd64" -O buildifier
+          chmod +x ./buildifier
+          ./buildifier -lint=warn -mode=check -warnings=all -r ${{ github.workspace }}
+          rm ./buildifier
+        env:
+          BUILDIFIER_VERSION: 8.0.2

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,17 +3,29 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "bazel_features", version = "1.19.0",)
+bazel_dep(name = "bazel_features", version = "1.19.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "rules_foreign_cc", version = "0.12.0",)
+bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
 bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+
 bazel_dep(name = "stardoc", version = "0.7.1", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.3", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
 
 nasm = use_extension("//nasm:extensions.bzl", "nasm")
+nasm.toolchain(
+    _repo_name = "nasm_test_toolchains",
+    nasm_version = "2.16.03",
+)
+nasm.toolchain(
+    _repo_name = "nasm_test_toolchains",
+    nasm_version = "2.16.02",
+)
+nasm.toolchain(
+    _repo_name = "nasm_test_toolchains",
+    nasm_version = "2.16.01",
+)
+use_repo(nasm, "nasm_test_toolchains", "nasm_toolchains")
 
-nasm.toolchain(nasm_version = "2.16.03", _repo_name="nasm_test_toolchains")
-nasm.toolchain(nasm_version = "2.16.02", _repo_name="nasm_test_toolchains")
-nasm.toolchain(nasm_version = "2.16.01", _repo_name="nasm_test_toolchains")
-use_repo(nasm, "nasm_toolchains", "nasm_test_toolchains")
 register_toolchains("@nasm_toolchains//:all")

--- a/e2e/c_library/MODULE.bazel
+++ b/e2e/c_library/MODULE.bazel
@@ -9,7 +9,8 @@ module(
 )
 
 bazel_dep(name = "rules_nasm", version = "0.0.0")
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 
 local_path_override(
     module_name = "rules_nasm",

--- a/e2e/c_library/libadd/BUILD.bazel
+++ b/e2e/c_library/libadd/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_nasm//nasm:defs.bzl", "nasm_library")
 
 exports_files([
@@ -6,21 +7,21 @@ exports_files([
 
 cc_library(
     name = "add",
-    hdrs = ["add.h"],
     srcs = [
         "add.c",
         "x86/add_asm.h",
     ],
-    deps = [
-        "add_x86"
-    ],
+    hdrs = ["add.h"],
     visibility = ["//visibility:public"],
+    deps = [
+        "add_x86",
+    ],
 )
 
 nasm_library(
     name = "add_x86",
     src = "x86/add_x86.asm",
     hdrs = [
-        "x86/x86util.asm"
+        "x86/x86util.asm",
     ],
 )

--- a/e2e/c_library/libeq/BUILD.bazel
+++ b/e2e/c_library/libeq/BUILD.bazel
@@ -1,16 +1,17 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_nasm//nasm:defs.bzl", "nasm_library")
 
 cc_library(
     name = "eq",
-    hdrs = ["eq.h"],
     srcs = [
         "eq.c",
         "x86/eq_asm.h",
     ],
+    hdrs = ["eq.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":eq_x86",
     ],
-    visibility = ["//visibility:public"],
 )
 
 nasm_library(

--- a/e2e/c_library/tests/BUILD.bazel
+++ b/e2e/c_library/tests/BUILD.bazel
@@ -1,9 +1,11 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "add_test",
     size = "small",
     srcs = ["add_test.c"],
     deps = [
-        "//libadd:add"
+        "//libadd:add",
     ],
 )
 
@@ -12,7 +14,6 @@ cc_test(
     size = "small",
     srcs = ["eq_test.c"],
     deps = [
-        "//libeq:eq"
+        "//libeq:eq",
     ],
 )
-

--- a/e2e/diamond/MODULE.bazel
+++ b/e2e/diamond/MODULE.bazel
@@ -3,7 +3,7 @@ module(
 )
 
 bazel_dep(name = "rules_nasm", version = "0.1.0")
-bazel_dep(name = "rules_nasm_smoke",)
+bazel_dep(name = "rules_nasm_smoke")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 
@@ -11,6 +11,7 @@ local_path_override(
     module_name = "rules_nasm",
     path = "../..",
 )
+
 local_path_override(
     module_name = "rules_nasm_smoke",
     path = "../smoke",

--- a/e2e/second_degree/MODULE.bazel
+++ b/e2e/second_degree/MODULE.bazel
@@ -5,6 +5,8 @@ module(
 )
 
 bazel_dep(name = "rules_nasm_c_library", version = "0.0.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+
 local_path_override(
     module_name = "rules_nasm_c_library",
     path = "../c_library",

--- a/e2e/second_degree/MODULE.bazel
+++ b/e2e/second_degree/MODULE.bazel
@@ -5,11 +5,11 @@ module(
 )
 
 bazel_dep(name = "rules_nasm_c_library", version = "0.0.0")
-
 local_path_override(
     module_name = "rules_nasm_c_library",
     path = "../c_library",
 )
+
 local_path_override(
     module_name = "rules_nasm",
     path = "../..",

--- a/e2e/second_degree/libcompsum/BUILD.bazel
+++ b/e2e/second_degree/libcompsum/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_library(
     name = "compsum",
-    hdrs = ["compsum.h"],
     srcs = ["compsum.c"],
+    hdrs = ["compsum.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "@rules_nasm_c_library//libadd:add",
         "@rules_nasm_c_library//libeq:eq",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/e2e/second_degree/tests/BUILD.bazel
+++ b/e2e/second_degree/tests/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "compsum_test",
     size = "small",

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -2,9 +2,10 @@ module(
     name = "rules_nasm_smoke",
 )
 
-bazel_dep(name = "rules_nasm", version = "0.1.0")
+bazel_dep(name = "rules_nasm", version = "0.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 
 local_path_override(
     module_name = "rules_nasm",

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -17,6 +17,7 @@ fi
 
 for d in $(ls); do
     if [[ -d "$d" ]]; then
+        echo "$d"
         cd "$d"
         echo "TEST: bazel test //... ${@}"
         bazel $bazelrc test //... "${@}"

--- a/examples/cross_compilation/MODULE.bazel
+++ b/examples/cross_compilation/MODULE.bazel
@@ -4,7 +4,8 @@ module(
 
 bazel_dep(name = "rules_nasm", version = "0.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 
 local_path_override(
     module_name = "rules_nasm",

--- a/examples/cross_compilation/toolchains/BUILD.bazel
+++ b/examples/cross_compilation/toolchains/BUILD.bazel
@@ -1,21 +1,20 @@
+load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
 load("//toolchains:cc_toolchain_config.bzl", "cc_toolchain_config")
 
 filegroup(name = "empty")
 
 toolchain(
     name = "cc-compiler-x86-gnu",
-    toolchain = ":cc-compiler-x86-gnu_toolchain",
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
     target_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
+    toolchain = ":cc-compiler-x86-gnu_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 cc_toolchain(
     name = "cc-compiler-x86-gnu_toolchain",
-    toolchain_identifier = "cc-compiler-x86-gnu_toolchain",
-    toolchain_config = ":cc-compiler-x86-gnu_config",
     all_files = ":empty",
     compiler_files = ":empty",
     dwp_files = ":empty",
@@ -23,12 +22,14 @@ cc_toolchain(
     objcopy_files = ":empty",
     strip_files = ":empty",
     supports_param_files = 0,
+    toolchain_config = ":cc-compiler-x86-gnu_config",
+    toolchain_identifier = "cc-compiler-x86-gnu_toolchain",
 )
 
 cc_toolchain_config(
     name = "cc-compiler-x86-gnu_config",
-    toolchain_identifier = "x86_64-gnu",
     compiler = "gcc",
     compiler_version = "12",
+    toolchain_identifier = "x86_64-gnu",
     toolchain_prefix = "/usr/bin/x86_64-linux-gnu",
 )

--- a/examples/cross_compilation/toolchains/cc_toolchain_config.bzl
+++ b/examples/cross_compilation/toolchains/cc_toolchain_config.bzl
@@ -1,6 +1,7 @@
 """Simple CC toolchain configuration rule."""
 
 load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 
 def _cc_toolchain_config_impl(ctx):
     return cc_common.create_cc_toolchain_config_info(
@@ -17,35 +18,40 @@ def _cc_toolchain_config_impl(ctx):
             tool_path(
                 name = tool,
                 path = ctx.attr.toolchain_prefix + (
-                    "-%s-%s"%(ctx.attr.compiler, ctx.attr.compiler_version)
-                    if tool == "gcc" else "-%s"%tool
+                    "-%s-%s" % (ctx.attr.compiler, ctx.attr.compiler_version) if tool == "gcc" else "-%s" % tool
                 ),
             )
             for tool in [
-                "gcc", "cpp", "ld", "ar", "nm", "objdump", "strip"
+                "gcc",
+                "cpp",
+                "ld",
+                "ar",
+                "nm",
+                "objdump",
+                "strip",
             ]
         ],
         cxx_builtin_include_directories = [
             "/usr/x86_64-linux-gnu/include",
-        ]
+        ],
     )
 
 cc_toolchain_config = rule(
     implementation = _cc_toolchain_config_impl,
     attrs = {
-        "toolchain_identifier": attr.string(),
+        "abi_libc_version": attr.string(),
+        "abi_version": attr.string(),
+        "compiler": attr.string(),
+        "compiler_version": attr.string(
+            mandatory = True,
+            doc = "Major version of the compiler.",
+        ),
         "host_system_name": attr.string(default = "local"),
         "target_system_name": attr.string(default = "local"),
-        "compiler": attr.string(),
-        "abi_version": attr.string(),
-        "abi_libc_version": attr.string(),
+        "toolchain_identifier": attr.string(),
         "toolchain_prefix": attr.string(
-            mandatory=True,
-            doc = "Prefix path to toolchain binaries, eg [prefix]-ld."
-        ),
-        "compiler_version": attr.string(
-            mandatory=True,
-            doc = "Major version of the compiler."
+            mandatory = True,
+            doc = "Prefix path to toolchain binaries, eg [prefix]-ld.",
         ),
     },
     provides = [CcToolchainConfigInfo],

--- a/fetch_checksums.sh
+++ b/fetch_checksums.sh
@@ -35,6 +35,7 @@ if [ -n "$1" ]; then
 fi
 versions=( $(curl -L https://www.nasm.us/pub/nasm/releasebuilds/ --stderr - | grep -P '(?<=href=")\d+\.\d+\.\d+(rc\d+)?' -o) )
 
+echo "# buildifier: disable=module-docstring"
 echo "NASM_URLS = {"
 
 for v in "${versions[@]}"; do

--- a/nasm/BUILD.bazel
+++ b/nasm/BUILD.bazel
@@ -1,17 +1,20 @@
-toolchain_type(name = "toolchain_type", visibility = ["//visibility:public"])
-
-load("//nasm:nasm_toolchain.bzl", "nasm_assembler")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//nasm:nasm_toolchain.bzl", "nasm_assembler")
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
+    visibility = ["//:__subpackages__"],
     deps = [
         "//nasm/private/rules:binary",
         "//nasm/private/rules:library",
         "//nasm/private/rules:test",
     ],
-    visibility = ["//:__subpackages__"],
 )
 
 exports_files([

--- a/nasm/defs.bzl
+++ b/nasm/defs.bzl
@@ -2,9 +2,9 @@
 
 """Rules for `nasm`."""
 
+load("//nasm/private/rules:binary.bzl", _nasm_binary = "nasm_binary")
 load("//nasm/private/rules:library.bzl", _nasm_library = "nasm_library")
 load("//nasm/private/rules:test.bzl", _nasm_test = "nasm_test")
-load("//nasm/private/rules:binary.bzl", _nasm_binary = "nasm_binary")
 
 nasm_test = _nasm_test
 nasm_library = _nasm_library

--- a/nasm/extensions.bzl
+++ b/nasm/extensions.bzl
@@ -6,7 +6,7 @@
 load("//nasm:toolchains.bzl", "nasm_declare_toolchain_repos", "nasm_toolchains")
 
 OS_MAP = {
-    'mac os x': 'macos',
+    "mac os x": "macos",
 }
 
 _toolchain = tag_class(
@@ -23,8 +23,8 @@ _toolchain = tag_class(
         "_repo_name": attr.string(
             doc = ("Name of repo where toolchains will be registered. For internal use."),
             default = "nasm_toolchains",
-        )
-    }
+        ),
+    },
 )
 
 def get_unique_toolchain_tags(module_ctx):
@@ -51,9 +51,7 @@ def map_os(java_os):
 
 def _nasm_impl(module_ctx):
     host_os = map_os(module_ctx.os.name)
-    print(host_os)
     configurations = get_unique_toolchain_tags(module_ctx)
-    print(configurations)
     repo_names = nasm_declare_toolchain_repos(configurations, host_os)
     configuration_groups = {"nasm_toolchains": []}
     for configuration, groups in configurations.items():
@@ -64,7 +62,7 @@ def _nasm_impl(module_ctx):
     for name, toolchains in configuration_groups.items():
         nasm_toolchains(
             name = name,
-            toolchains = toolchains
+            toolchains = toolchains,
         )
 
 nasm = module_extension(

--- a/nasm/nasm_toolchain.bzl
+++ b/nasm/nasm_toolchain.bzl
@@ -13,12 +13,12 @@ def _nasm_toolchain_impl(ctx):
 nasm_toolchain = rule(
     implementation = _nasm_toolchain_impl,
     attrs = {
+        "args": attr.string_list(),
         "target": attr.label(
             cfg = "exec",
             allow_files = True,
             executable = True,
         ),
-        "args": attr.string_list(),
     },
 )
 
@@ -31,7 +31,7 @@ def _nasm_assembler_impl(ctx):
         is_executable = True,
     )
     return [
-        DefaultInfo(files = depset([symlink]))
+        DefaultInfo(files = depset([symlink])),
     ]
 
 nasm_assembler = rule(

--- a/nasm/private/rules/binary.bzl
+++ b/nasm/private/rules/binary.bzl
@@ -2,9 +2,10 @@
 
 """Rule for nasm binary targets."""
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load(":library.bzl", "nasm_library")
 
-def nasm_binary(name, src, hdrs=None, preincs=None, includes=None, **kwargs):
+def nasm_binary(name, src, hdrs = None, preincs = None, includes = None, **kwargs):
     """Assemble a source file as an executable.
 
     Assembles an `nasm` source file as an executable binary. The
@@ -41,9 +42,8 @@ def nasm_binary(name, src, hdrs=None, preincs=None, includes=None, **kwargs):
         preincs = preincs,
         includes = includes,
     )
-
-    native.cc_binary(
+    cc_binary(
         name = name,
-        srcs = [":%s_lib"%name],
+        srcs = [":%s_lib" % name],
         **kwargs
     )

--- a/nasm/private/rules/test.bzl
+++ b/nasm/private/rules/test.bzl
@@ -2,9 +2,10 @@
 
 """Rule for nasm test targets."""
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load(":library.bzl", "nasm_library")
 
-def nasm_test(name, src, size=None, hdrs=None, preincs=None, includes=None, **kwargs):
+def nasm_test(name, src, size = None, hdrs = None, preincs = None, includes = None, **kwargs):
     """Assemble and execute a test assembly program.
 
     Args:
@@ -28,10 +29,9 @@ def nasm_test(name, src, size=None, hdrs=None, preincs=None, includes=None, **kw
         preincs = preincs,
         includes = includes,
     )
-
-    native.cc_test(
+    cc_test(
         name = name,
         size = size,
-        srcs = [":%s_lib"%name],
+        srcs = [":%s_lib" % name],
         **kwargs
     )

--- a/nasm/private/urls.bzl
+++ b/nasm/private/urls.bzl
@@ -1,406 +1,205 @@
+# buildifier: disable=module-docstring
 NASM_URLS = {
-   "https://www.nasm.us/pub/nasm/releasebuilds/0.99.05/nasm-0.99.05.tar.gz":
-   "cfaa2908af8321b320b279d3fe040960ba044db2e9f6a95251de24a3068c231d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/0.99.06/nasm-0.99.06.tar.gz":
-   "e5f11b3fe812edfa236cde5f826af9878f80a63d05768e18e5282483a6f33c0c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.03.01/nasm-2.03.01.tar.gz":
-   "574ea6746a4f590971f4e694c55811adf77fe50951b5da133647f74c8b5fcc53",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.05.01/nasm-2.05.01.tar.gz":
-   "f2ca9640a5dc0df66875c6970d40da7a82350b2a01a3981b0e7ac4ba973645ec",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.08.01/nasm-2.08.01.tar.gz":
-   "25c53b2c396bebddfce31e4c1c92150d599de6b57a64aa323e0994e10223f751",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.08.01/macosx/nasm-2.08.01-macosx.zip":
-   "53d20616003e2fc69602d41ed341c5b39c2b03d7de776aa8ea8001a854f9ac19",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.08.02/nasm-2.08.02.tar.gz":
-   "cd85081b47981ee83f1058d3e2faa80f392c901fd675de1386e992caadc0b6c9",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.08.02/macosx/nasm-2.08.02-macosx.zip":
-   "be2182a7507db956efece5edaa49a8d33fc471e33e9947225cb38fecd37b6cbf",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.01/nasm-2.09.01.tar.gz":
-   "cc840f60185eb56bcab1de4dadb6ce686c66a4d7c2f3d8719769a37682337102",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.01/macosx/nasm-2.09.01-macosx.zip":
-   "0069a6a2e8ddcb33d1ecaa9d162a1e3f03b0dedb9a18273ec1251cdf006a46be",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.02/nasm-2.09.02.tar.gz":
-   "e813e13798b54c72377323c8837fe83ea06c14e63ce212b21c1a4ccc667537b5",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.02/macosx/nasm-2.09.02-macosx.zip":
-   "ba777a5781abe944084e6a83ceee0165ae115137d899b6c424e0cc1b67b7a8ab",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.03/nasm-2.09.03.tar.gz":
-   "2532dc46604f8b8d70232d525ab5052a1f8202d2ed640445ef6d3ca1051fe102",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.03/macosx/nasm-2.09.03-macosx.zip":
-   "d1a3b37fb33c5ca999da01ffe27b88306d9691c0d199c620389e6d7bbdd682db",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.04/nasm-2.09.04.tar.gz":
-   "af0bb6f48deb9de3cdbf696a5ff26e33a6a05e16321c58da87e225437d7a51a2",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.04/macosx/nasm-2.09.04-macosx.zip":
-   "c12ad2a5ae63adf2dc5fe08427acb1b955deffe5b0b7905cee1897693307ead6",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.05/nasm-2.09.05.tar.gz":
-   "b90f1c0aaae93f18d2ae27680f87e8b29f015d69c684d4b9113c53020ee4c9e3",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.05/macosx/nasm-2.09.05-macosx.zip":
-   "9609fc33a8b80f28da3e834cac112bdf6dd225d77709bc76c7d3f2f6be8a2c53",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.06/nasm-2.09.06.tar.gz":
-   "3b191c1feb893cb53ddc7e90841d2082cd6c3ff06de5149dd61fb42683b8e5b1",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.06/macosx/nasm-2.09.06-macosx.zip":
-   "3bbfc8ba876ef1be81bd2e7f5c80848510176cfe8cb1e7d27803ffd485d4e79f",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.07/nasm-2.09.07.tar.gz":
-   "ac6b33eade18462aa17587392bdbe1a8adf4fc686c919723f002ccb8b7956e6b",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.07/macosx/nasm-2.09.07-macosx.zip":
-   "05069fc5fd441e0852731090b334732c4be884aba72157de5355a5ddc0280011",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.08/nasm-2.09.08.tar.gz":
-   "7230521097e1fdd4e8e60a64737c056c0a839e4572dba6a9bb1a5ca9ebfea359",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.08/macosx/nasm-2.09.08-macosx.zip":
-   "1c222b611d0bb4d5444f52e1e33ad41cca6bb32b2d66005b449bf7407ffb5bd2",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.09/nasm-2.09.09.tar.gz":
-   "c8dcb4abc271902ddd61f32ce4c586d0791f77da1550f2c14c75a975a7ce0d60",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.09/macosx/nasm-2.09.09-macosx.zip":
-   "a2cdbcc7ca0c3639a5409ea7475ac94e2bf2f57c310d95c6479b069ed3ac2d8a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.10/nasm-2.09.10.tar.gz":
-   "e787b3ec90b2e065056171d138f57052f68c18e6ccde7106d819d6838ff94bb4",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.09.10/macosx/nasm-2.09.10-macosx.zip":
-   "13417245df6e03c295d29104e6b307d0b74c4f7adcccd6e4d0556cf665e4a019",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.01/nasm-2.10.01.tar.gz":
-   "c7b324bea8fabf6ddb14d375d117857b20e8d978bb675f5b85398c8b5778034f",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.01/macosx/nasm-2.10.01-macosx.zip":
-   "fda372c710e252a6bccb2f166f046aeb1ae957aca9d5b525a6f70d0be309efc2",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.02/nasm-2.10.02.tar.gz":
-   "d4aa0ee04200be1758b52f19ef19273fb74ca317bd0a9688e65e85c7307d965c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.02/macosx/nasm-2.10.02-macosx.zip":
-   "7cf5822509bd9d29e145b976deb8a26aee8c118ba668dfb74e3864a19aa02756",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.03/nasm-2.10.03.tar.gz":
-   "dad9eb188bea4a510587d5696942393e82d570b2faa81b46f5551f488f1b3ac3",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.03/macosx/nasm-2.10.03-macosx.zip":
-   "81df241b136a1458cca68c3a62422998e49b23aa078b35a5b04194e7db895dc7",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.04/nasm-2.10.04.tar.gz":
-   "3f83031522b54bf8c6dfdf87ea91e4c02b859cd75ed16f71700d6c9f5c3bc396",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.04/macosx/nasm-2.10.04-macosx.zip":
-   "aa647472826461b40fdc95b48d9b748cd21723dae470d5517c1a8d884cc5b63f",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.05/nasm-2.10.05.tar.gz":
-   "cdad08ad0a8502cfbb37e041fc65367bc9f710c40fb728b2a37966930dbd7d42",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.05/macosx/nasm-2.10.05-macosx.zip":
-   "7b1a107ec18a69f6f0cb9ea84056482455de62f84d05f700b1bb83674f6f0404",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.06/nasm-2.10.06.tar.gz":
-   "096194affbcb69f70bf3ac4eab528ad6dd397ce534d9843cd7850d62a8a52c95",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.06/macosx/nasm-2.10.06-macosx.zip":
-   "7b83e87191f7173fe0619b347d63eac834456ea7cfcab6ea0d26a0cfa788129a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.07/nasm-2.10.07.tar.gz":
-   "cbd03de25021c045482db7b239cd407b91719f3f42ef38e5e72100dde381fc88",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.07/macosx/nasm-2.10.07-macosx.zip":
-   "726fd1c8a78b133395869a7f29684bd567949cbcbbda5cc0b9c09912505b443d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.08/nasm-2.10.08.tar.gz":
-   "435e8e123654ed793e96463fdd75b79c1071428f385292c8c25a9e3fb9342911",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.08/macosx/nasm-2.10.08-macosx.zip":
-   "3d959f19bfe124bba02c9297cd3c7d27b44497511d27df5a4314a21f6cac8370",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.09/nasm-2.10.09.tar.gz":
-   "469b40eddfac35fa5bbc0454981ba104cf579d3d1503b34b90b428b04e660bb7",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.10.09/macosx/nasm-2.10.09-macosx.zip":
-   "89752155a76f824387d0f21d3edd29100a252008b2972596250d364e22a604c4",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.01/nasm-2.11.01.tar.gz":
-   "9977b695d13be524fe3c5195b373c53d768cd819a9154f5160ee6b312347c3cd",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.01/macosx/nasm-2.11.01-macosx.zip":
-   "dc271ed018613c830f7b6ec4aaf389a64296291496266bb3d61b37c10cc54c2e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02/nasm-2.11.02.tar.gz":
-   "781290ff457e6f59e10c7da12b65180189bb26ca6015cf7fdfd531c4b2b3eedc",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02/macosx/nasm-2.11.02-macosx.zip":
-   "b0e0c2263f7f5a02356814813353709ff386a22584cdf2bfdb7ab53b45b9270b",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02rc6/nasm-2.11.02rc6.tar.gz":
-   "272cf1681460dc752f64829c80d91819d794190d2262e269f12ff541282e1fd8",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02rc6/macosx/nasm-2.11.02rc6-macosx.zip":
-   "bf59744e8dbfacc8a05ae9c93af15aabcb5d81fbc74db136045b6749023ecc97",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.03/nasm-2.11.03.tar.gz":
-   "b417ea743278e6afdf49f358aada0f74e89d24a70aff0b5a3010e45c95fbdcf3",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.03/macosx/nasm-2.11.03-macosx.zip":
-   "524809f260f9fa585de4fdf5380976463dc9a6b9dffb92e89d1104ff9eac0e8d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.04/nasm-2.11.04.tar.gz":
-   "9db5973f392a51733eb69f15db45df84ca93a3e1986850d7581b20b63d562abf",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.04/macosx/nasm-2.11.04-macosx.zip":
-   "ab5523ac4861128e2c3b07d90b19bc8fb938f9e90b2abfe89a44ab6eb440599a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.05/nasm-2.11.05.tar.gz":
-   "102c5497eeb6505e5b8e5afc698cf6210f261929b5e3c8b92bbf73c03b072459",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.05/macosx/nasm-2.11.05-macosx.zip":
-   "7ae67831740d08de3f3e351feadba3453759ced692e1a4835a62a03e712098b9",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.06/nasm-2.11.06.tar.gz":
-   "3a72476f3cb45294d303f4d34f20961b15323ac24e84eb41bc130714979123bb",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.06/macosx/nasm-2.11.06-macosx.zip":
-   "147f0f4044c836c0607a05be80adc9de91af51ef64ad285322f4bf7e49d25c68",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.08/nasm-2.11.08.tar.gz":
-   "e76596043d67d31c61321adf4ab8e1768974c1b497b8d4e9adf64d8b83fb19c0",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.08/macosx/nasm-2.11.08-macosx.zip":
-   "b7fa5f653c3b81083777858d2a5cc0d1ab23533989f12a0d7e01017873d4443c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc1/nasm-2.11.09rc1.tar.gz":
-   "4e1d8231cb733c61d41d4976240cbfcd9a17129e951911139914cfa54612ba04",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc1/macosx/nasm-2.11.09rc1-macosx.zip":
-   "a214f62fd3b7ad76862f8bccee215d9ed7c3b26146e6c0209fe8ad28d9653015",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc2/nasm-2.11.09rc2.tar.gz":
-   "2f6bff699d64b6b3341adc6d09fbcdaf209035c1eb8a8ef443b8f21812aa539a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc2/macosx/nasm-2.11.09rc2-macosx.zip":
-   "7cd70e85e976fc3fe3da28b0a97321a181a663ff2e42a6efa63f59074ea8eb67",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01/nasm-2.12.01.tar.gz":
-   "4cab94c041ae85740b47d92d0a25dd2325f05b2378dcf6fac4d09c49c62ee481",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01/macosx/nasm-2.12.01-macosx.zip":
-   "f8358a257b1597052084754090dfe565bea436c105d23e713a69d27006c31aa9",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc1/nasm-2.12.01rc1.tar.gz":
-   "4cff99aabd6b7c457fec37831af2bda59433970edc236f57906391243328f47b",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc1/macosx/nasm-2.12.01rc1-macosx.zip":
-   "4ee0bf287890c2846e65fdf3a8642e2979f56538e28da1176fbc4bfc4228e444",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc2/nasm-2.12.01rc2.tar.gz":
-   "1f37c4d4871b3e6c65c058111f9b9b570ace2f6204bc82cb0f36b469c2827636",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc2/macosx/nasm-2.12.01rc2-macosx.zip":
-   "ea752e52452f31f0aa6c7dda6672ab10194274f99d893be765b77077abf184ee",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02/nasm-2.12.02.tar.gz":
-   "b7346d827b282ccf70608fe90b9bcf27effb1ddbd1bcba8a5ab4be95284fd01b",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02/macosx/nasm-2.12.02-macosx.zip":
-   "2599d8be419d7f0e141afb680c79801736c65e9ec3ff428a70e4f620aea7e2d3",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc1/nasm-2.12.02rc1.tar.gz":
-   "af4339eab6975b8cb609e6117f2f1735bce59b1026e55c1ee1ae0975805ea107",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc1/macosx/nasm-2.12.02rc1-macosx.zip":
-   "cef4e1c6d3535f22bd1363fbdd80e4a4d977d2d7bad260ebfac96224c690a12a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc3/nasm-2.12.02rc3.tar.gz":
-   "c68b0490fb132583a921dc7e0a14e266de3cc77c9b633fff0d8406d5c3552105",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc3/macosx/nasm-2.12.02rc3-macosx.zip":
-   "26dcfc023912ac942deab51513fc764435ec901df72812f667813db0d2e04a90",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc4/nasm-2.12.02rc4.tar.gz":
-   "0d61c2b71851f5e638703a0a868cd611ca7d41b1791e4f47e59093dab1878fab",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc4/macosx/nasm-2.12.02rc4-macosx.zip":
-   "3fe5748b9415675be942494b86154322d5bff4b8d51ff238a09553079bacfbee",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc5/nasm-2.12.02rc5.tar.gz":
-   "ea905af320e89c76b22909abb035da76fed5b8375845333892813b9a77f1c058",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc5/macosx/nasm-2.12.02rc5-macosx.zip":
-   "e3569a07944552c4402cb159359583be0e1319f773538c00de90dd0544085751",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc6/nasm-2.12.02rc6.tar.gz":
-   "64d668df4682f0c2f8b4c57f3e88ee1d8dbb1166ebe0d8977b5e24037d6f512e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc6/macosx/nasm-2.12.02rc6-macosx.zip":
-   "1fd5e2585eb6a32ab96b8246c86b7948b3cd0ec69d497d4838aa9085259eb4e1",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc7/nasm-2.12.02rc7.tar.gz":
-   "bcfbb3e571982944f8c6e029174e1f3d61b90204a3737fe14696fe30ef0c81f6",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc7/macosx/nasm-2.12.02rc7-macosx.zip":
-   "468d34f00f272103562337ec68d981714985d84cd69d2014e08d27c2c06af66d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc8/nasm-2.12.02rc8.tar.gz":
-   "16f17476380cf4f4bf3bf19216d566770fc30d6f06a6c736b195974514eda33a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc8/macosx/nasm-2.12.02rc8-macosx.zip":
-   "85487fcd903b2007c02391b572ddb219b594a38ea8b8b3a677245254544306c8",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc9/nasm-2.12.02rc9.tar.gz":
-   "02998a916c48e7a3cd4f2be8e9da71daf1918a9a413fc4b3ee3f110e45b8e050",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc9/macosx/nasm-2.12.02rc9-macosx.zip":
-   "ef0bad5fd1bebf17efc901533f0d09f594a9b4216b04c5dad6f7968a72a4561c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.03rc1/nasm-2.12.03rc1.tar.gz":
-   "55d4da067b4bffb0f3e0b5ddf07bf746aea9519d9266649ab308a0be0840969e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.12.03rc1/macosx/nasm-2.12.03rc1-macosx.zip":
-   "d67faf2b7844813084f7f3ddcf11e14d44b65ed78d9966a610ea5ff22a4deb0e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.01/nasm-2.13.01.tar.gz":
-   "0cd4327b114e459a84717260fad4238b445d3511cf0341249072204867698e09",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.01/macosx/nasm-2.13.01-macosx.zip":
-   "db0f1118950430f6e72c3cc394e2d63fa69cb9c61528c61a264d5c999deb0b66",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.gz":
-   "62df25fa783f272a82a3053d99b848f64c5e007221748f1f012a404a32827c1f",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/macosx/nasm-2.13.02-macosx.zip":
-   "49ac6b9dabc67aa6de7a198ae9257ba2c931474c841a715f585a738ba7c8264e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc1/nasm-2.13.02rc1.tar.gz":
-   "cbd1410cdabcdc11010d3ccc2c248e79301762f83be9186a57667bd9d362875e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc1/macosx/nasm-2.13.02rc1-macosx.zip":
-   "8524d1c10c0fc74679a62155dd952a96de37de1e49dc61fcadacd890a52ce436",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc2/nasm-2.13.02rc2.tar.gz":
-   "57c0933d0e5b30f9ddb814dc1bbe5063ee367cf9151c2d866b0ba90fb299923a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc2/macosx/nasm-2.13.02rc2-macosx.zip":
-   "26becc39486205f7b79f0cb334ffe82d835967193b8b81c9f2250ced5d3932b9",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc3/nasm-2.13.02rc3.tar.gz":
-   "46f251bd0f98ffdc2e44c252823b85da083c91e8af9dd9720648ced62488ccf7",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc3/macosx/nasm-2.13.02rc3-macosx.zip":
-   "18d6d9ab9859bbc38c2f42f1814891c7d7bb73af8550878ef142ca54c88ff28a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.gz":
-   "23e1b679d64024863e2991e5c166e19309f0fe58a9765622b35bd31be5b2cc99",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/macosx/nasm-2.13.03-macosx.zip":
-   "a757d65d8c6fdcee258b649972014029bb5413c4cb226db4e9579863d503410f",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc1/nasm-2.13.03rc1.tar.gz":
-   "e815872927500841b6a7d0e7daa71722940938dba3ecdae29714d50924f7d7ad",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc1/macosx/nasm-2.13.03rc1-macosx.zip":
-   "caac6b4c33210cada124a8279cb6a3615662c360f6a0f5f109225f258bf3a87c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc6/nasm-2.13.03rc6.tar.gz":
-   "3856848260e0b6e0f1ed65e0a2bf44ae4f05a12b8c347f54a5d7fe6be2fa5002",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc6/macosx/nasm-2.13.03rc6-macosx.zip":
-   "c21f7d795facbdd9fbc646820a67a41030e7e3a486022414a2fbb3806e201124",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01/nasm-2.14.01.tar.gz":
-   "1d3cd4cd4cd850437408d02f6d87370cc5f9b9b8f9dd253145c204aa2b99fdb0",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01/macosx/nasm-2.14.01-macosx.zip":
-   "b86e500a6466588fedb7f6490ef6409b21d63c5ca334e471bb8215504c911741",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc1/nasm-2.14.01rc1.tar.gz":
-   "fae05aa6a242f39fa672b53698d9ea4cc5c8d7d7bea5775302ab32126b39d6e2",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc1/macosx/nasm-2.14.01rc1-macosx.zip":
-   "badc8763409f995eaf604014076ce31a57a41f141fa88d0f0aa0cda59e9e6e85",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc2/nasm-2.14.01rc2.tar.gz":
-   "b33af47688883bfefa79d1c076cbcba4573316bbb653442815ea7ace4d78b0ae",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc2/macosx/nasm-2.14.01rc2-macosx.zip":
-   "2d117a596cf05896034c6fc349b47f774310db10a9c1866b7e0c94da16c3ece3",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc3/nasm-2.14.01rc3.tar.gz":
-   "95207a66418640b1b5c6edfb216808d9128bb1c2c27a059ba5765dfdb0b93d29",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc3/macosx/nasm-2.14.01rc3-macosx.zip":
-   "56fe716f168a830937133286576ec88e52a3c4b22e4121620388a07fef418e35",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc4/nasm-2.14.01rc4.tar.gz":
-   "7d61214ae891fcf8db706af4f8b333b6a15ca9f5758e0503ecb22c82c5d675b4",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc4/macosx/nasm-2.14.01rc4-macosx.zip":
-   "bc57a5f6c8287e3155f65845dc163e1737defc9bcce33337c2585e3d0001aa93",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc5/nasm-2.14.01rc5.tar.gz":
-   "b52322b8fe2817e9206239898debdb27b0e657d43419cf11be58ee320bf1ebc9",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc5/macosx/nasm-2.14.01rc5-macosx.zip":
-   "f5400bdf388a3a398441af6c42fa3f5cc57721e320e12d4e3ab894f2b234cd7c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz":
-   "b34bae344a3f2ed93b2ca7bf25f1ed3fb12da89eeda6096e3551fd66adeae9fc",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/macosx/nasm-2.14.02-macosx.zip":
-   "8904a395f45be9d608c630ecc711360400303f5a02a17abf69b6b911b7d61544",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc1/nasm-2.14.03rc1.tar.gz":
-   "5f06823362b90d1c2b8631bc2a6edda16650df18140967ecdb9a5d7bbf6c8594",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc1/macosx/nasm-2.14.03rc1-macosx.zip":
-   "7e8a95340b31b9271d10cf0281b06fbe9c78224cf1f7926164fc98a225cd9392",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc2/nasm-2.14.03rc2.tar.gz":
-   "fc51d1fb16d7784a1fc03138f473346f2ce6d5c67f9e1e7e23847a5997c71161",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc2/macosx/nasm-2.14.03rc2-macosx.zip":
-   "be45ac425466064ea68ce0a8f62aea0556fc979524b50711f763c8eaefe2f1db",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.01/nasm-2.15.01.tar.gz":
-   "d98c3d0bf8aea524db0a63d8e93b241adcf94f6fb4cb3446fbc95ebd4fa430c3",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.01/macosx/nasm-2.15.01-macosx.zip":
-   "3ae10f5e2f0e43801af50a15bc5f11566e4ee2e97d68ebdfbbb7b454d80c9e44",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02/nasm-2.15.02.tar.gz":
-   "ba04bc6f03af6a890298697b26a4b183569bb65e6f9665bbc4ca69c138d0f643",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02/macosx/nasm-2.15.02-macosx.zip":
-   "ba4fd239b27b36d78b5e6926312436380aa68f1160f62a39953ce72dcf8c74e7",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02rc2/nasm-2.15.02rc2.tar.gz":
-   "455a2ebcf4ea0a73bcaa2302e74a821ce38b5977d0d8d2fcd1ec1f344f677486",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02rc2/macosx/nasm-2.15.02rc2-macosx.zip":
-   "1b41e4ea7c2035af6dac04506c3f1dae8cc66c0082181bb8d7f08086a51180b2",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03/nasm-2.15.03.tar.gz":
-   "450d98ce85d1e01fa19c0f60ecdc55b0a17301100d2438803836f84df803fa0d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03/macosx/nasm-2.15.03-macosx.zip":
-   "24b9b5ada1df0b29ca43ff3b7d66e9562e9e833b883f44b8c42fe1af1fa0dbea",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc1/nasm-2.15.03rc1.tar.gz":
-   "9daa7ba15b590645391d151b8c36cd68faee3740c7de7b11bbe437ca3cdc7334",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc1/macosx/nasm-2.15.03rc1-macosx.zip":
-   "a96be47b745ca132b90bd9aa9c28467b3020f8fd7d08ff442e0cfa7919b0127a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc2/nasm-2.15.03rc2.tar.gz":
-   "6b48405de36a8a9a23da5dd58c7bb311beef5e9f4802fcce3d1712198eff1c5d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc2/macosx/nasm-2.15.03rc2-macosx.zip":
-   "18c99f480b9cbecf7612f105d40ccb8aad2d2d86876f89b2acf3983dcb67fb0a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc3/nasm-2.15.03rc3.tar.gz":
-   "f2dfdc044e9825bf1e3b2842bd92193d8405b6b911a83a705e44b34882202dc5",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc3/macosx/nasm-2.15.03rc3-macosx.zip":
-   "304c3ebcdaca2e0400e33925478ff379bb0468d04b850bf357d17694909cb5d7",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc4/nasm-2.15.03rc4.tar.gz":
-   "f8e762b5ad597a1a6aac0f9caa9aab6b5a2b98ec2c69f810946d1f28ee975424",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc4/macosx/nasm-2.15.03rc4-macosx.zip":
-   "342199313d52f3b41b705da993d34f3432664658f4bbed14aedfb0ae005f78c0",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc5/nasm-2.15.03rc5.tar.gz":
-   "718992cf1c70347b6ecc026a5a2f8decfcf33d871b1c49a95925aa8a00392ecc",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc5/macosx/nasm-2.15.03rc5-macosx.zip":
-   "5dfee59d95941b66beb62fb77afd36c59ff6b3ce2e7b5915bd881cb0b81114d9",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc6/nasm-2.15.03rc6.tar.gz":
-   "dfc394108daa2f253cbe14fd665b49c08f178750d99bc6442f14e7ebf4a04666",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc6/macosx/nasm-2.15.03rc6-macosx.zip":
-   "0a4119ca09cfea8d279268e1702eb4e832a81168194666c1feac98604eff9cfc",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc7/nasm-2.15.03rc7.tar.gz":
-   "21f6826b129413e477c62226fca81110feeb73db491480cedb736bcf9f87363f",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc7/macosx/nasm-2.15.03rc7-macosx.zip":
-   "7c513228ae3228a897dafd8633f80c6699edab7f94c33a79ddee68ced6c01ef3",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc8/nasm-2.15.03rc8.tar.gz":
-   "f9a2612647cd26d7f258f55e910fed78268ada95e95e214a8b123dea798a37a8",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc8/macosx/nasm-2.15.03rc8-macosx.zip":
-   "a63896054618948e1e3f70f0bc953387c7f45520796f073e569d2848bd0ff46c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04/nasm-2.15.04.tar.gz":
-   "8ff3bf164c4f21337d3405a987be7a04f02913bc773453afe66124a9e109a0d5",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04/macosx/nasm-2.15.04-macosx.zip":
-   "7cce3628d7a28279989d97363425fb9eb04ef312f43f95db8c804ec9b5a1426d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc1/nasm-2.15.04rc1.tar.gz":
-   "b7c0cbeedfa9d56d48c6d2307d9c580a4a339981926319358f42c22333b0e274",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc1/macosx/nasm-2.15.04rc1-macosx.zip":
-   "59bd375c37f90ea11af9e22308f9638fdbb368a41d496805e6918a4242fe1875",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc2/nasm-2.15.04rc2.tar.gz":
-   "ab306dcdd95fce7d1238f3584f476bb89b3652173c01ffe8c3faa13968c0e994",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc2/macosx/nasm-2.15.04rc2-macosx.zip":
-   "3204b42791f8db1216214bc6e69451fe0a1253d1a2bd6a9413ea26450629693e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc3/nasm-2.15.04rc3.tar.gz":
-   "9866c1dd5c4bba69955790aa1aa376f8ba35ccfec42b587d26b8eae55d05b03e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc3/macosx/nasm-2.15.04rc3-macosx.zip":
-   "88428e9eed51c0d457812f5a7f0e2cbd4466af5e4c8ad2fabd0bcff8f9af8598",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc4/nasm-2.15.04rc4.tar.gz":
-   "a15816cdec4c3a7fa91e93331a84f917b44cde08671d754d8276a17ebe53c382",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc4/macosx/nasm-2.15.04rc4-macosx.zip":
-   "8f1815fd54f780695b6302a14c5a08e5e2fbc6d54021dbe1eee158610211e940",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc5/nasm-2.15.04rc5.tar.gz":
-   "3cf2fea9ec212e4db2548e648baa0e0f575f87e1d954ab4bc06eb5d8027450d4",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc5/macosx/nasm-2.15.04rc5-macosx.zip":
-   "eb84141f72ad277e15ab4c72da02f700c6c45d532e02c9a121395ed2d9b02896",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc6/nasm-2.15.04rc6.tar.gz":
-   "4ea0e4d547cd94c983429140123cd7ed88f10b0676f75958f7b7e43bebfe9e6a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc6/macosx/nasm-2.15.04rc6-macosx.zip":
-   "42fb2a501305fde6e86a8e83bf7fe847b39b647a0488a8aa8aaabd70ebda5bda",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz":
-   "9182a118244b058651c576baa9d0366ee05983c4d4ae1d9ddd3236a9f2304997",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/macosx/nasm-2.15.05-macosx.zip":
-   "6c1368ee6252b9ba7825011e5e2446fa8d6b713e7d87f19fe1933682e32c6d90",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc1/nasm-2.15.05rc1.tar.gz":
-   "31c052b1038d7317b87e226598afe8793e669bd6109c7105abcf25d1e2fd813b",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc1/macosx/nasm-2.15.05rc1-macosx.zip":
-   "88ade367b9a925a1860588b17267e0ecc7a3682ff54b7538e8d92aeb0d2a5001",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc2/nasm-2.15.05rc2.tar.gz":
-   "b868d67c4d0e2ecee27efb58a8895c2327439af4c859920f745cfc65024a05ca",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc2/macosx/nasm-2.15.05rc2-macosx.zip":
-   "56db1744ed62d5cfcbfc498ad2d709b27598cca69a78769cd07af360e038878c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.gz":
-   "d833bf0f5716e89dbcd345b7f545f25fe348c6e2ef16dbc293e1027bcd22d881",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/macosx/nasm-2.16.01-macosx.zip":
-   "d53c9a1bc9cd92d22e37924d31e9c68413fa03104fd165a6e7b7faf8800a1822",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02/nasm-2.16.02.tar.gz":
-   "3ab7ca964f741fc05efc50689382f6730fce96bc73e4e74e5fcce66cc973abce",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02/macosx/nasm-2.16.02-macosx.zip":
-   "d7459f023ee439735e94391fb900690c40b8652d448bad6bf0e894a8943a26f5",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc1/nasm-2.16.02rc1.tar.gz":
-   "477cfd3643e09067e78e7c4abe07b56401a0ea39c0f655b7eb5cac1fa35270ad",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc1/macosx/nasm-2.16.02rc1-macosx.zip":
-   "48fe9155fe0b732b7065a0b98e1d18a56388d2497ff85b9feba2833a37f11f08",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc2/nasm-2.16.02rc2.tar.gz":
-   "3dad25c8da172bdf63e009bd51628b9e4f444a8e8b82e2e2dd57fe2f429751b8",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc2/macosx/nasm-2.16.02rc2-macosx.zip":
-   "001cb3153c367706e5a546dc7c27098cd7eceafd5e24d038d13ef21f09700df7",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc3/nasm-2.16.02rc3.tar.gz":
-   "a6db6050250314ede428e770c4928cb68ac815c584f3f6e1b6425330c9b88c36",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc3/macosx/nasm-2.16.02rc3-macosx.zip":
-   "8bacce6f1072deb286dbaa2fdcbeeafb43216cb5112a93b4632f59519ac53330",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc4/nasm-2.16.02rc4.tar.gz":
-   "33cd3836158a7a48420aa9e2e02dbf4134996c81352add417cfc62b830389bb5",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc4/macosx/nasm-2.16.02rc4-macosx.zip":
-   "7fdeb9a8a2aaeae1f3ac8649fd36f93d670a6826e96ff21a7968b5a1f6b108bf",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc5/nasm-2.16.02rc5.tar.gz":
-   "35bd2fe7f589140c4731edcaa42b74d83db76a17571567a702a6f32db4cd01b0",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc5/macosx/nasm-2.16.02rc5-macosx.zip":
-   "8bd97b14cc004e522649067e7ff612212949a68f2467b5600afb5f55ef74b91e",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc6/nasm-2.16.02rc6.tar.gz":
-   "948fcecf6802c89fda8f62f3290199e62a1e07158cc17cef36e77112e5d9f33d",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc6/macosx/nasm-2.16.02rc6-macosx.zip":
-   "66bf782a89d54c74315a5eba944fd7d7e4ffdfec3132b5fd94f3031990ca8679",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc7/nasm-2.16.02rc7.tar.gz":
-   "8c8dd9a08e7a5669e73ff34a3561bb14e8368532b48a5d87fc32ec941399a888",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc7/macosx/nasm-2.16.02rc7-macosx.zip":
-   "8c9dc2ad9c535c2c9819f3eb60889829b8de2b570fd93886e037cfd11a3c405c",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc8/nasm-2.16.02rc8.tar.gz":
-   "c1273637142367a0a1452ad293c2ed62cf39f22034b762dfcac207671e0cdf84",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc8/macosx/nasm-2.16.02rc8-macosx.zip":
-   "b1d8fda490ef5e66ec88b21525b0456d5c255b25ee7552a5c4380ea6fa1b5418",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc9/nasm-2.16.02rc9.tar.gz":
-   "eea740d773e3a9239ce1617d610ae851e8d1ba36c46e9c4e5abf3d6bdff0cf9f",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc9/macosx/nasm-2.16.02rc9-macosx.zip":
-   "e79fa896e169c1161a1db01f61ef752b65bd47f36bb34d34341aa7afc6488037",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc10/nasm-2.16.02rc10.tar.gz":
-   "1d3b31d133a5a194835fc437cad3fca6d69e989fb34d822273e6aea2e9f5ebd2",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc10/macosx/nasm-2.16.02rc10-macosx.zip":
-   "86ca9bb3dca15ea99cf4fc573a5a454c657208f6c1c34963df673c6615b45614",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.gz":
-   "5bc940dd8a4245686976a8f7e96ba9340a0915f2d5b88356874890e207bdb581",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/macosx/nasm-2.16.03-macosx.zip":
-   "0d29bcd8a5fc617333f4549c7c1f93d1866a4a0915c40359e0a8585bb1a5aa75",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc1/nasm-2.16.03rc1.tar.gz":
-   "73ba1906cc296482769b2f4c8c7f5b76b730466c5dad731e12eb534cb1046888",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc1/macosx/nasm-2.16.03rc1-macosx.zip":
-   "cb88647e3d2a636b88d8097bcf3e0c9b53d7a0d1f5cf16d9225ba2c3a10748af",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc2/nasm-2.16.03rc2.tar.gz":
-   "ce1e426a765ff9cd5f7675b054b6fe4e24f4f5b044f8ed92718a3e6c4de0167b",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc2/macosx/nasm-2.16.03rc2-macosx.zip":
-   "2bdb41eb5136fce7e27aa3d2a093e2e1dcbb7c8b67712cf2daa3af6ef3ead86a",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc3/nasm-2.16.03rc3.tar.gz":
-   "b94bf6c4e6c4797b791814b38cbd5a507c240a9859c75a489e1cf756e399adfc",
-   "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc3/macosx/nasm-2.16.03rc3-macosx.zip":
-   "67a7d9894c280f4d3911afad672d9e7c47ea63d3f41f1a8f21d24c5f58c48d3e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/0.99.05/nasm-0.99.05.tar.gz": "cfaa2908af8321b320b279d3fe040960ba044db2e9f6a95251de24a3068c231d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/0.99.06/nasm-0.99.06.tar.gz": "e5f11b3fe812edfa236cde5f826af9878f80a63d05768e18e5282483a6f33c0c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.03.01/nasm-2.03.01.tar.gz": "574ea6746a4f590971f4e694c55811adf77fe50951b5da133647f74c8b5fcc53",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.05.01/nasm-2.05.01.tar.gz": "f2ca9640a5dc0df66875c6970d40da7a82350b2a01a3981b0e7ac4ba973645ec",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.08.01/macosx/nasm-2.08.01-macosx.zip": "53d20616003e2fc69602d41ed341c5b39c2b03d7de776aa8ea8001a854f9ac19",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.08.01/nasm-2.08.01.tar.gz": "25c53b2c396bebddfce31e4c1c92150d599de6b57a64aa323e0994e10223f751",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.08.02/macosx/nasm-2.08.02-macosx.zip": "be2182a7507db956efece5edaa49a8d33fc471e33e9947225cb38fecd37b6cbf",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.08.02/nasm-2.08.02.tar.gz": "cd85081b47981ee83f1058d3e2faa80f392c901fd675de1386e992caadc0b6c9",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.01/macosx/nasm-2.09.01-macosx.zip": "0069a6a2e8ddcb33d1ecaa9d162a1e3f03b0dedb9a18273ec1251cdf006a46be",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.01/nasm-2.09.01.tar.gz": "cc840f60185eb56bcab1de4dadb6ce686c66a4d7c2f3d8719769a37682337102",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.02/macosx/nasm-2.09.02-macosx.zip": "ba777a5781abe944084e6a83ceee0165ae115137d899b6c424e0cc1b67b7a8ab",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.02/nasm-2.09.02.tar.gz": "e813e13798b54c72377323c8837fe83ea06c14e63ce212b21c1a4ccc667537b5",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.03/macosx/nasm-2.09.03-macosx.zip": "d1a3b37fb33c5ca999da01ffe27b88306d9691c0d199c620389e6d7bbdd682db",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.03/nasm-2.09.03.tar.gz": "2532dc46604f8b8d70232d525ab5052a1f8202d2ed640445ef6d3ca1051fe102",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.04/macosx/nasm-2.09.04-macosx.zip": "c12ad2a5ae63adf2dc5fe08427acb1b955deffe5b0b7905cee1897693307ead6",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.04/nasm-2.09.04.tar.gz": "af0bb6f48deb9de3cdbf696a5ff26e33a6a05e16321c58da87e225437d7a51a2",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.05/macosx/nasm-2.09.05-macosx.zip": "9609fc33a8b80f28da3e834cac112bdf6dd225d77709bc76c7d3f2f6be8a2c53",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.05/nasm-2.09.05.tar.gz": "b90f1c0aaae93f18d2ae27680f87e8b29f015d69c684d4b9113c53020ee4c9e3",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.06/macosx/nasm-2.09.06-macosx.zip": "3bbfc8ba876ef1be81bd2e7f5c80848510176cfe8cb1e7d27803ffd485d4e79f",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.06/nasm-2.09.06.tar.gz": "3b191c1feb893cb53ddc7e90841d2082cd6c3ff06de5149dd61fb42683b8e5b1",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.07/macosx/nasm-2.09.07-macosx.zip": "05069fc5fd441e0852731090b334732c4be884aba72157de5355a5ddc0280011",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.07/nasm-2.09.07.tar.gz": "ac6b33eade18462aa17587392bdbe1a8adf4fc686c919723f002ccb8b7956e6b",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.08/macosx/nasm-2.09.08-macosx.zip": "1c222b611d0bb4d5444f52e1e33ad41cca6bb32b2d66005b449bf7407ffb5bd2",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.08/nasm-2.09.08.tar.gz": "7230521097e1fdd4e8e60a64737c056c0a839e4572dba6a9bb1a5ca9ebfea359",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.09/macosx/nasm-2.09.09-macosx.zip": "a2cdbcc7ca0c3639a5409ea7475ac94e2bf2f57c310d95c6479b069ed3ac2d8a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.09/nasm-2.09.09.tar.gz": "c8dcb4abc271902ddd61f32ce4c586d0791f77da1550f2c14c75a975a7ce0d60",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.10/macosx/nasm-2.09.10-macosx.zip": "13417245df6e03c295d29104e6b307d0b74c4f7adcccd6e4d0556cf665e4a019",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.09.10/nasm-2.09.10.tar.gz": "e787b3ec90b2e065056171d138f57052f68c18e6ccde7106d819d6838ff94bb4",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.01/macosx/nasm-2.10.01-macosx.zip": "fda372c710e252a6bccb2f166f046aeb1ae957aca9d5b525a6f70d0be309efc2",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.01/nasm-2.10.01.tar.gz": "c7b324bea8fabf6ddb14d375d117857b20e8d978bb675f5b85398c8b5778034f",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.02/macosx/nasm-2.10.02-macosx.zip": "7cf5822509bd9d29e145b976deb8a26aee8c118ba668dfb74e3864a19aa02756",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.02/nasm-2.10.02.tar.gz": "d4aa0ee04200be1758b52f19ef19273fb74ca317bd0a9688e65e85c7307d965c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.03/macosx/nasm-2.10.03-macosx.zip": "81df241b136a1458cca68c3a62422998e49b23aa078b35a5b04194e7db895dc7",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.03/nasm-2.10.03.tar.gz": "dad9eb188bea4a510587d5696942393e82d570b2faa81b46f5551f488f1b3ac3",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.04/macosx/nasm-2.10.04-macosx.zip": "aa647472826461b40fdc95b48d9b748cd21723dae470d5517c1a8d884cc5b63f",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.04/nasm-2.10.04.tar.gz": "3f83031522b54bf8c6dfdf87ea91e4c02b859cd75ed16f71700d6c9f5c3bc396",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.05/macosx/nasm-2.10.05-macosx.zip": "7b1a107ec18a69f6f0cb9ea84056482455de62f84d05f700b1bb83674f6f0404",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.05/nasm-2.10.05.tar.gz": "cdad08ad0a8502cfbb37e041fc65367bc9f710c40fb728b2a37966930dbd7d42",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.06/macosx/nasm-2.10.06-macosx.zip": "7b83e87191f7173fe0619b347d63eac834456ea7cfcab6ea0d26a0cfa788129a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.06/nasm-2.10.06.tar.gz": "096194affbcb69f70bf3ac4eab528ad6dd397ce534d9843cd7850d62a8a52c95",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.07/macosx/nasm-2.10.07-macosx.zip": "726fd1c8a78b133395869a7f29684bd567949cbcbbda5cc0b9c09912505b443d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.07/nasm-2.10.07.tar.gz": "cbd03de25021c045482db7b239cd407b91719f3f42ef38e5e72100dde381fc88",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.08/macosx/nasm-2.10.08-macosx.zip": "3d959f19bfe124bba02c9297cd3c7d27b44497511d27df5a4314a21f6cac8370",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.08/nasm-2.10.08.tar.gz": "435e8e123654ed793e96463fdd75b79c1071428f385292c8c25a9e3fb9342911",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.09/macosx/nasm-2.10.09-macosx.zip": "89752155a76f824387d0f21d3edd29100a252008b2972596250d364e22a604c4",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.10.09/nasm-2.10.09.tar.gz": "469b40eddfac35fa5bbc0454981ba104cf579d3d1503b34b90b428b04e660bb7",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.01/macosx/nasm-2.11.01-macosx.zip": "dc271ed018613c830f7b6ec4aaf389a64296291496266bb3d61b37c10cc54c2e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.01/nasm-2.11.01.tar.gz": "9977b695d13be524fe3c5195b373c53d768cd819a9154f5160ee6b312347c3cd",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02/macosx/nasm-2.11.02-macosx.zip": "b0e0c2263f7f5a02356814813353709ff386a22584cdf2bfdb7ab53b45b9270b",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02/nasm-2.11.02.tar.gz": "781290ff457e6f59e10c7da12b65180189bb26ca6015cf7fdfd531c4b2b3eedc",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02rc6/macosx/nasm-2.11.02rc6-macosx.zip": "bf59744e8dbfacc8a05ae9c93af15aabcb5d81fbc74db136045b6749023ecc97",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.02rc6/nasm-2.11.02rc6.tar.gz": "272cf1681460dc752f64829c80d91819d794190d2262e269f12ff541282e1fd8",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.03/macosx/nasm-2.11.03-macosx.zip": "524809f260f9fa585de4fdf5380976463dc9a6b9dffb92e89d1104ff9eac0e8d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.03/nasm-2.11.03.tar.gz": "b417ea743278e6afdf49f358aada0f74e89d24a70aff0b5a3010e45c95fbdcf3",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.04/macosx/nasm-2.11.04-macosx.zip": "ab5523ac4861128e2c3b07d90b19bc8fb938f9e90b2abfe89a44ab6eb440599a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.04/nasm-2.11.04.tar.gz": "9db5973f392a51733eb69f15db45df84ca93a3e1986850d7581b20b63d562abf",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.05/macosx/nasm-2.11.05-macosx.zip": "7ae67831740d08de3f3e351feadba3453759ced692e1a4835a62a03e712098b9",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.05/nasm-2.11.05.tar.gz": "102c5497eeb6505e5b8e5afc698cf6210f261929b5e3c8b92bbf73c03b072459",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.06/macosx/nasm-2.11.06-macosx.zip": "147f0f4044c836c0607a05be80adc9de91af51ef64ad285322f4bf7e49d25c68",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.06/nasm-2.11.06.tar.gz": "3a72476f3cb45294d303f4d34f20961b15323ac24e84eb41bc130714979123bb",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.08/macosx/nasm-2.11.08-macosx.zip": "b7fa5f653c3b81083777858d2a5cc0d1ab23533989f12a0d7e01017873d4443c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.08/nasm-2.11.08.tar.gz": "e76596043d67d31c61321adf4ab8e1768974c1b497b8d4e9adf64d8b83fb19c0",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc1/macosx/nasm-2.11.09rc1-macosx.zip": "a214f62fd3b7ad76862f8bccee215d9ed7c3b26146e6c0209fe8ad28d9653015",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc1/nasm-2.11.09rc1.tar.gz": "4e1d8231cb733c61d41d4976240cbfcd9a17129e951911139914cfa54612ba04",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc2/macosx/nasm-2.11.09rc2-macosx.zip": "7cd70e85e976fc3fe3da28b0a97321a181a663ff2e42a6efa63f59074ea8eb67",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.11.09rc2/nasm-2.11.09rc2.tar.gz": "2f6bff699d64b6b3341adc6d09fbcdaf209035c1eb8a8ef443b8f21812aa539a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01/macosx/nasm-2.12.01-macosx.zip": "f8358a257b1597052084754090dfe565bea436c105d23e713a69d27006c31aa9",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01/nasm-2.12.01.tar.gz": "4cab94c041ae85740b47d92d0a25dd2325f05b2378dcf6fac4d09c49c62ee481",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc1/macosx/nasm-2.12.01rc1-macosx.zip": "4ee0bf287890c2846e65fdf3a8642e2979f56538e28da1176fbc4bfc4228e444",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc1/nasm-2.12.01rc1.tar.gz": "4cff99aabd6b7c457fec37831af2bda59433970edc236f57906391243328f47b",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc2/macosx/nasm-2.12.01rc2-macosx.zip": "ea752e52452f31f0aa6c7dda6672ab10194274f99d893be765b77077abf184ee",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.01rc2/nasm-2.12.01rc2.tar.gz": "1f37c4d4871b3e6c65c058111f9b9b570ace2f6204bc82cb0f36b469c2827636",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02/macosx/nasm-2.12.02-macosx.zip": "2599d8be419d7f0e141afb680c79801736c65e9ec3ff428a70e4f620aea7e2d3",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02/nasm-2.12.02.tar.gz": "b7346d827b282ccf70608fe90b9bcf27effb1ddbd1bcba8a5ab4be95284fd01b",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc1/macosx/nasm-2.12.02rc1-macosx.zip": "cef4e1c6d3535f22bd1363fbdd80e4a4d977d2d7bad260ebfac96224c690a12a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc1/nasm-2.12.02rc1.tar.gz": "af4339eab6975b8cb609e6117f2f1735bce59b1026e55c1ee1ae0975805ea107",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc3/macosx/nasm-2.12.02rc3-macosx.zip": "26dcfc023912ac942deab51513fc764435ec901df72812f667813db0d2e04a90",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc3/nasm-2.12.02rc3.tar.gz": "c68b0490fb132583a921dc7e0a14e266de3cc77c9b633fff0d8406d5c3552105",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc4/macosx/nasm-2.12.02rc4-macosx.zip": "3fe5748b9415675be942494b86154322d5bff4b8d51ff238a09553079bacfbee",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc4/nasm-2.12.02rc4.tar.gz": "0d61c2b71851f5e638703a0a868cd611ca7d41b1791e4f47e59093dab1878fab",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc5/macosx/nasm-2.12.02rc5-macosx.zip": "e3569a07944552c4402cb159359583be0e1319f773538c00de90dd0544085751",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc5/nasm-2.12.02rc5.tar.gz": "ea905af320e89c76b22909abb035da76fed5b8375845333892813b9a77f1c058",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc6/macosx/nasm-2.12.02rc6-macosx.zip": "1fd5e2585eb6a32ab96b8246c86b7948b3cd0ec69d497d4838aa9085259eb4e1",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc6/nasm-2.12.02rc6.tar.gz": "64d668df4682f0c2f8b4c57f3e88ee1d8dbb1166ebe0d8977b5e24037d6f512e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc7/macosx/nasm-2.12.02rc7-macosx.zip": "468d34f00f272103562337ec68d981714985d84cd69d2014e08d27c2c06af66d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc7/nasm-2.12.02rc7.tar.gz": "bcfbb3e571982944f8c6e029174e1f3d61b90204a3737fe14696fe30ef0c81f6",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc8/macosx/nasm-2.12.02rc8-macosx.zip": "85487fcd903b2007c02391b572ddb219b594a38ea8b8b3a677245254544306c8",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc8/nasm-2.12.02rc8.tar.gz": "16f17476380cf4f4bf3bf19216d566770fc30d6f06a6c736b195974514eda33a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc9/macosx/nasm-2.12.02rc9-macosx.zip": "ef0bad5fd1bebf17efc901533f0d09f594a9b4216b04c5dad6f7968a72a4561c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.02rc9/nasm-2.12.02rc9.tar.gz": "02998a916c48e7a3cd4f2be8e9da71daf1918a9a413fc4b3ee3f110e45b8e050",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.03rc1/macosx/nasm-2.12.03rc1-macosx.zip": "d67faf2b7844813084f7f3ddcf11e14d44b65ed78d9966a610ea5ff22a4deb0e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.12.03rc1/nasm-2.12.03rc1.tar.gz": "55d4da067b4bffb0f3e0b5ddf07bf746aea9519d9266649ab308a0be0840969e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.01/macosx/nasm-2.13.01-macosx.zip": "db0f1118950430f6e72c3cc394e2d63fa69cb9c61528c61a264d5c999deb0b66",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.01/nasm-2.13.01.tar.gz": "0cd4327b114e459a84717260fad4238b445d3511cf0341249072204867698e09",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/macosx/nasm-2.13.02-macosx.zip": "49ac6b9dabc67aa6de7a198ae9257ba2c931474c841a715f585a738ba7c8264e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.gz": "62df25fa783f272a82a3053d99b848f64c5e007221748f1f012a404a32827c1f",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc1/macosx/nasm-2.13.02rc1-macosx.zip": "8524d1c10c0fc74679a62155dd952a96de37de1e49dc61fcadacd890a52ce436",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc1/nasm-2.13.02rc1.tar.gz": "cbd1410cdabcdc11010d3ccc2c248e79301762f83be9186a57667bd9d362875e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc2/macosx/nasm-2.13.02rc2-macosx.zip": "26becc39486205f7b79f0cb334ffe82d835967193b8b81c9f2250ced5d3932b9",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc2/nasm-2.13.02rc2.tar.gz": "57c0933d0e5b30f9ddb814dc1bbe5063ee367cf9151c2d866b0ba90fb299923a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc3/macosx/nasm-2.13.02rc3-macosx.zip": "18d6d9ab9859bbc38c2f42f1814891c7d7bb73af8550878ef142ca54c88ff28a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02rc3/nasm-2.13.02rc3.tar.gz": "46f251bd0f98ffdc2e44c252823b85da083c91e8af9dd9720648ced62488ccf7",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/macosx/nasm-2.13.03-macosx.zip": "a757d65d8c6fdcee258b649972014029bb5413c4cb226db4e9579863d503410f",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.gz": "23e1b679d64024863e2991e5c166e19309f0fe58a9765622b35bd31be5b2cc99",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc1/macosx/nasm-2.13.03rc1-macosx.zip": "caac6b4c33210cada124a8279cb6a3615662c360f6a0f5f109225f258bf3a87c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc1/nasm-2.13.03rc1.tar.gz": "e815872927500841b6a7d0e7daa71722940938dba3ecdae29714d50924f7d7ad",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc6/macosx/nasm-2.13.03rc6-macosx.zip": "c21f7d795facbdd9fbc646820a67a41030e7e3a486022414a2fbb3806e201124",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03rc6/nasm-2.13.03rc6.tar.gz": "3856848260e0b6e0f1ed65e0a2bf44ae4f05a12b8c347f54a5d7fe6be2fa5002",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01/macosx/nasm-2.14.01-macosx.zip": "b86e500a6466588fedb7f6490ef6409b21d63c5ca334e471bb8215504c911741",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01/nasm-2.14.01.tar.gz": "1d3cd4cd4cd850437408d02f6d87370cc5f9b9b8f9dd253145c204aa2b99fdb0",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc1/macosx/nasm-2.14.01rc1-macosx.zip": "badc8763409f995eaf604014076ce31a57a41f141fa88d0f0aa0cda59e9e6e85",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc1/nasm-2.14.01rc1.tar.gz": "fae05aa6a242f39fa672b53698d9ea4cc5c8d7d7bea5775302ab32126b39d6e2",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc2/macosx/nasm-2.14.01rc2-macosx.zip": "2d117a596cf05896034c6fc349b47f774310db10a9c1866b7e0c94da16c3ece3",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc2/nasm-2.14.01rc2.tar.gz": "b33af47688883bfefa79d1c076cbcba4573316bbb653442815ea7ace4d78b0ae",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc3/macosx/nasm-2.14.01rc3-macosx.zip": "56fe716f168a830937133286576ec88e52a3c4b22e4121620388a07fef418e35",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc3/nasm-2.14.01rc3.tar.gz": "95207a66418640b1b5c6edfb216808d9128bb1c2c27a059ba5765dfdb0b93d29",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc4/macosx/nasm-2.14.01rc4-macosx.zip": "bc57a5f6c8287e3155f65845dc163e1737defc9bcce33337c2585e3d0001aa93",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc4/nasm-2.14.01rc4.tar.gz": "7d61214ae891fcf8db706af4f8b333b6a15ca9f5758e0503ecb22c82c5d675b4",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc5/macosx/nasm-2.14.01rc5-macosx.zip": "f5400bdf388a3a398441af6c42fa3f5cc57721e320e12d4e3ab894f2b234cd7c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.01rc5/nasm-2.14.01rc5.tar.gz": "b52322b8fe2817e9206239898debdb27b0e657d43419cf11be58ee320bf1ebc9",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/macosx/nasm-2.14.02-macosx.zip": "8904a395f45be9d608c630ecc711360400303f5a02a17abf69b6b911b7d61544",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz": "b34bae344a3f2ed93b2ca7bf25f1ed3fb12da89eeda6096e3551fd66adeae9fc",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc1/macosx/nasm-2.14.03rc1-macosx.zip": "7e8a95340b31b9271d10cf0281b06fbe9c78224cf1f7926164fc98a225cd9392",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc1/nasm-2.14.03rc1.tar.gz": "5f06823362b90d1c2b8631bc2a6edda16650df18140967ecdb9a5d7bbf6c8594",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc2/macosx/nasm-2.14.03rc2-macosx.zip": "be45ac425466064ea68ce0a8f62aea0556fc979524b50711f763c8eaefe2f1db",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.14.03rc2/nasm-2.14.03rc2.tar.gz": "fc51d1fb16d7784a1fc03138f473346f2ce6d5c67f9e1e7e23847a5997c71161",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.01/macosx/nasm-2.15.01-macosx.zip": "3ae10f5e2f0e43801af50a15bc5f11566e4ee2e97d68ebdfbbb7b454d80c9e44",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.01/nasm-2.15.01.tar.gz": "d98c3d0bf8aea524db0a63d8e93b241adcf94f6fb4cb3446fbc95ebd4fa430c3",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02/macosx/nasm-2.15.02-macosx.zip": "ba4fd239b27b36d78b5e6926312436380aa68f1160f62a39953ce72dcf8c74e7",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02/nasm-2.15.02.tar.gz": "ba04bc6f03af6a890298697b26a4b183569bb65e6f9665bbc4ca69c138d0f643",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02rc2/macosx/nasm-2.15.02rc2-macosx.zip": "1b41e4ea7c2035af6dac04506c3f1dae8cc66c0082181bb8d7f08086a51180b2",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.02rc2/nasm-2.15.02rc2.tar.gz": "455a2ebcf4ea0a73bcaa2302e74a821ce38b5977d0d8d2fcd1ec1f344f677486",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03/macosx/nasm-2.15.03-macosx.zip": "24b9b5ada1df0b29ca43ff3b7d66e9562e9e833b883f44b8c42fe1af1fa0dbea",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03/nasm-2.15.03.tar.gz": "450d98ce85d1e01fa19c0f60ecdc55b0a17301100d2438803836f84df803fa0d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc1/macosx/nasm-2.15.03rc1-macosx.zip": "a96be47b745ca132b90bd9aa9c28467b3020f8fd7d08ff442e0cfa7919b0127a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc1/nasm-2.15.03rc1.tar.gz": "9daa7ba15b590645391d151b8c36cd68faee3740c7de7b11bbe437ca3cdc7334",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc2/macosx/nasm-2.15.03rc2-macosx.zip": "18c99f480b9cbecf7612f105d40ccb8aad2d2d86876f89b2acf3983dcb67fb0a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc2/nasm-2.15.03rc2.tar.gz": "6b48405de36a8a9a23da5dd58c7bb311beef5e9f4802fcce3d1712198eff1c5d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc3/macosx/nasm-2.15.03rc3-macosx.zip": "304c3ebcdaca2e0400e33925478ff379bb0468d04b850bf357d17694909cb5d7",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc3/nasm-2.15.03rc3.tar.gz": "f2dfdc044e9825bf1e3b2842bd92193d8405b6b911a83a705e44b34882202dc5",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc4/macosx/nasm-2.15.03rc4-macosx.zip": "342199313d52f3b41b705da993d34f3432664658f4bbed14aedfb0ae005f78c0",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc4/nasm-2.15.03rc4.tar.gz": "f8e762b5ad597a1a6aac0f9caa9aab6b5a2b98ec2c69f810946d1f28ee975424",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc5/macosx/nasm-2.15.03rc5-macosx.zip": "5dfee59d95941b66beb62fb77afd36c59ff6b3ce2e7b5915bd881cb0b81114d9",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc5/nasm-2.15.03rc5.tar.gz": "718992cf1c70347b6ecc026a5a2f8decfcf33d871b1c49a95925aa8a00392ecc",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc6/macosx/nasm-2.15.03rc6-macosx.zip": "0a4119ca09cfea8d279268e1702eb4e832a81168194666c1feac98604eff9cfc",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc6/nasm-2.15.03rc6.tar.gz": "dfc394108daa2f253cbe14fd665b49c08f178750d99bc6442f14e7ebf4a04666",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc7/macosx/nasm-2.15.03rc7-macosx.zip": "7c513228ae3228a897dafd8633f80c6699edab7f94c33a79ddee68ced6c01ef3",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc7/nasm-2.15.03rc7.tar.gz": "21f6826b129413e477c62226fca81110feeb73db491480cedb736bcf9f87363f",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc8/macosx/nasm-2.15.03rc8-macosx.zip": "a63896054618948e1e3f70f0bc953387c7f45520796f073e569d2848bd0ff46c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.03rc8/nasm-2.15.03rc8.tar.gz": "f9a2612647cd26d7f258f55e910fed78268ada95e95e214a8b123dea798a37a8",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04/macosx/nasm-2.15.04-macosx.zip": "7cce3628d7a28279989d97363425fb9eb04ef312f43f95db8c804ec9b5a1426d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04/nasm-2.15.04.tar.gz": "8ff3bf164c4f21337d3405a987be7a04f02913bc773453afe66124a9e109a0d5",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc1/macosx/nasm-2.15.04rc1-macosx.zip": "59bd375c37f90ea11af9e22308f9638fdbb368a41d496805e6918a4242fe1875",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc1/nasm-2.15.04rc1.tar.gz": "b7c0cbeedfa9d56d48c6d2307d9c580a4a339981926319358f42c22333b0e274",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc2/macosx/nasm-2.15.04rc2-macosx.zip": "3204b42791f8db1216214bc6e69451fe0a1253d1a2bd6a9413ea26450629693e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc2/nasm-2.15.04rc2.tar.gz": "ab306dcdd95fce7d1238f3584f476bb89b3652173c01ffe8c3faa13968c0e994",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc3/macosx/nasm-2.15.04rc3-macosx.zip": "88428e9eed51c0d457812f5a7f0e2cbd4466af5e4c8ad2fabd0bcff8f9af8598",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc3/nasm-2.15.04rc3.tar.gz": "9866c1dd5c4bba69955790aa1aa376f8ba35ccfec42b587d26b8eae55d05b03e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc4/macosx/nasm-2.15.04rc4-macosx.zip": "8f1815fd54f780695b6302a14c5a08e5e2fbc6d54021dbe1eee158610211e940",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc4/nasm-2.15.04rc4.tar.gz": "a15816cdec4c3a7fa91e93331a84f917b44cde08671d754d8276a17ebe53c382",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc5/macosx/nasm-2.15.04rc5-macosx.zip": "eb84141f72ad277e15ab4c72da02f700c6c45d532e02c9a121395ed2d9b02896",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc5/nasm-2.15.04rc5.tar.gz": "3cf2fea9ec212e4db2548e648baa0e0f575f87e1d954ab4bc06eb5d8027450d4",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc6/macosx/nasm-2.15.04rc6-macosx.zip": "42fb2a501305fde6e86a8e83bf7fe847b39b647a0488a8aa8aaabd70ebda5bda",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.04rc6/nasm-2.15.04rc6.tar.gz": "4ea0e4d547cd94c983429140123cd7ed88f10b0676f75958f7b7e43bebfe9e6a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/macosx/nasm-2.15.05-macosx.zip": "6c1368ee6252b9ba7825011e5e2446fa8d6b713e7d87f19fe1933682e32c6d90",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz": "9182a118244b058651c576baa9d0366ee05983c4d4ae1d9ddd3236a9f2304997",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc1/macosx/nasm-2.15.05rc1-macosx.zip": "88ade367b9a925a1860588b17267e0ecc7a3682ff54b7538e8d92aeb0d2a5001",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc1/nasm-2.15.05rc1.tar.gz": "31c052b1038d7317b87e226598afe8793e669bd6109c7105abcf25d1e2fd813b",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc2/macosx/nasm-2.15.05rc2-macosx.zip": "56db1744ed62d5cfcbfc498ad2d709b27598cca69a78769cd07af360e038878c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05rc2/nasm-2.15.05rc2.tar.gz": "b868d67c4d0e2ecee27efb58a8895c2327439af4c859920f745cfc65024a05ca",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/macosx/nasm-2.16.01-macosx.zip": "d53c9a1bc9cd92d22e37924d31e9c68413fa03104fd165a6e7b7faf8800a1822",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.gz": "d833bf0f5716e89dbcd345b7f545f25fe348c6e2ef16dbc293e1027bcd22d881",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02/macosx/nasm-2.16.02-macosx.zip": "d7459f023ee439735e94391fb900690c40b8652d448bad6bf0e894a8943a26f5",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02/nasm-2.16.02.tar.gz": "3ab7ca964f741fc05efc50689382f6730fce96bc73e4e74e5fcce66cc973abce",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc1/macosx/nasm-2.16.02rc1-macosx.zip": "48fe9155fe0b732b7065a0b98e1d18a56388d2497ff85b9feba2833a37f11f08",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc1/nasm-2.16.02rc1.tar.gz": "477cfd3643e09067e78e7c4abe07b56401a0ea39c0f655b7eb5cac1fa35270ad",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc10/macosx/nasm-2.16.02rc10-macosx.zip": "86ca9bb3dca15ea99cf4fc573a5a454c657208f6c1c34963df673c6615b45614",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc10/nasm-2.16.02rc10.tar.gz": "1d3b31d133a5a194835fc437cad3fca6d69e989fb34d822273e6aea2e9f5ebd2",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc2/macosx/nasm-2.16.02rc2-macosx.zip": "001cb3153c367706e5a546dc7c27098cd7eceafd5e24d038d13ef21f09700df7",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc2/nasm-2.16.02rc2.tar.gz": "3dad25c8da172bdf63e009bd51628b9e4f444a8e8b82e2e2dd57fe2f429751b8",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc3/macosx/nasm-2.16.02rc3-macosx.zip": "8bacce6f1072deb286dbaa2fdcbeeafb43216cb5112a93b4632f59519ac53330",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc3/nasm-2.16.02rc3.tar.gz": "a6db6050250314ede428e770c4928cb68ac815c584f3f6e1b6425330c9b88c36",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc4/macosx/nasm-2.16.02rc4-macosx.zip": "7fdeb9a8a2aaeae1f3ac8649fd36f93d670a6826e96ff21a7968b5a1f6b108bf",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc4/nasm-2.16.02rc4.tar.gz": "33cd3836158a7a48420aa9e2e02dbf4134996c81352add417cfc62b830389bb5",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc5/macosx/nasm-2.16.02rc5-macosx.zip": "8bd97b14cc004e522649067e7ff612212949a68f2467b5600afb5f55ef74b91e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc5/nasm-2.16.02rc5.tar.gz": "35bd2fe7f589140c4731edcaa42b74d83db76a17571567a702a6f32db4cd01b0",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc6/macosx/nasm-2.16.02rc6-macosx.zip": "66bf782a89d54c74315a5eba944fd7d7e4ffdfec3132b5fd94f3031990ca8679",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc6/nasm-2.16.02rc6.tar.gz": "948fcecf6802c89fda8f62f3290199e62a1e07158cc17cef36e77112e5d9f33d",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc7/macosx/nasm-2.16.02rc7-macosx.zip": "8c9dc2ad9c535c2c9819f3eb60889829b8de2b570fd93886e037cfd11a3c405c",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc7/nasm-2.16.02rc7.tar.gz": "8c8dd9a08e7a5669e73ff34a3561bb14e8368532b48a5d87fc32ec941399a888",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc8/macosx/nasm-2.16.02rc8-macosx.zip": "b1d8fda490ef5e66ec88b21525b0456d5c255b25ee7552a5c4380ea6fa1b5418",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc8/nasm-2.16.02rc8.tar.gz": "c1273637142367a0a1452ad293c2ed62cf39f22034b762dfcac207671e0cdf84",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc9/macosx/nasm-2.16.02rc9-macosx.zip": "e79fa896e169c1161a1db01f61ef752b65bd47f36bb34d34341aa7afc6488037",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.02rc9/nasm-2.16.02rc9.tar.gz": "eea740d773e3a9239ce1617d610ae851e8d1ba36c46e9c4e5abf3d6bdff0cf9f",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/macosx/nasm-2.16.03-macosx.zip": "0d29bcd8a5fc617333f4549c7c1f93d1866a4a0915c40359e0a8585bb1a5aa75",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.gz": "5bc940dd8a4245686976a8f7e96ba9340a0915f2d5b88356874890e207bdb581",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc1/macosx/nasm-2.16.03rc1-macosx.zip": "cb88647e3d2a636b88d8097bcf3e0c9b53d7a0d1f5cf16d9225ba2c3a10748af",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc1/nasm-2.16.03rc1.tar.gz": "73ba1906cc296482769b2f4c8c7f5b76b730466c5dad731e12eb534cb1046888",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc2/macosx/nasm-2.16.03rc2-macosx.zip": "2bdb41eb5136fce7e27aa3d2a093e2e1dcbb7c8b67712cf2daa3af6ef3ead86a",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc2/nasm-2.16.03rc2.tar.gz": "ce1e426a765ff9cd5f7675b054b6fe4e24f4f5b044f8ed92718a3e6c4de0167b",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc3/macosx/nasm-2.16.03rc3-macosx.zip": "67a7d9894c280f4d3911afad672d9e7c47ea63d3f41f1a8f21d24c5f58c48d3e",
+    "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03rc3/nasm-2.16.03rc3.tar.gz": "b94bf6c4e6c4797b791814b38cbd5a507c240a9859c75a489e1cf756e399adfc",
 }

--- a/nasm/toolchains.bzl
+++ b/nasm/toolchains.bzl
@@ -23,9 +23,11 @@ def nasm_declare_toolchain_repos(configurations, host_os):
 
 def canonical_name(version, source, os):
     """Get canonical name for toolchain repository."""
-    name = "%s_%s_%s"%(os, version, source)
+    name = "%s_%s_%s" % (os, version, source)
     return name.lower().replace(" ", "")
 
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def nasm_declare_repo(version, require_source, os):
     """Declare a nasm repository."""
     if os == "macos" and not require_source:
@@ -36,11 +38,13 @@ def nasm_declare_repo(version, require_source, os):
             return name
     url, checksum = nasm_get_url(version, "source")
     if checksum == None:
-        fail("No nasm release found for %s, %s."%(version, os))
+        fail("No nasm release found for %s, %s." % (version, os))
     name = canonical_name(version, "source", os)
     nasm_declare_repo_source(name, version, url, checksum)
     return name
 
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def nasm_define_toolchain(name):
     """Define a toolchain rule based on a toolchain name."""
     os = name.split("_")[0]
@@ -69,7 +73,7 @@ def _nasm_toolchains_impl(rctx):
     toolchains = [nasm_define_toolchain(tc) for tc in rctx.attr.toolchains]
     rctx.file(
         "BUILD.bazel",
-        "\n\n".join(toolchains)
+        "\n\n".join(toolchains),
     )
 
 nasm_toolchains = repository_rule(
@@ -77,10 +81,12 @@ nasm_toolchains = repository_rule(
     configure = True,
     local = True,
     attrs = {
-        "toolchains": attr.string_list()
+        "toolchains": attr.string_list(),
     },
 )
 
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def nasm_get_url(version, platform):
     """Get the URL and checksum for a version."""
     if platform == "macos":

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -16,5 +16,5 @@ platform(
     constraint_values = [
         ":elf",
         "@platforms//cpu:x86_64",
-    ]
+    ],
 )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,7 +1,8 @@
 # Copyright (c) 2024 Morgan Wajda-Levie.
 
-load("@rules_nasm//nasm:defs.bzl", "nasm_test", "nasm_library", "nasm_binary")
-
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_nasm//nasm:defs.bzl", "nasm_binary", "nasm_library", "nasm_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 nasm_test(
     name = "nasm_test_test",
@@ -33,7 +34,7 @@ sh_test(
     srcs = select({
         "@platforms//os:linux": [":nasm_executable"],
         "@platforms//os:macos": [":nasm_executable_mac"],
-    })
+    }),
 )
 
 nasm_binary(
@@ -66,7 +67,7 @@ nasm_test(
     size = "small",
     src = "preincs_main.asm",
     preincs = [
-        "includes_inc.asm"
+        "includes_inc.asm",
     ],
 )
 

--- a/tests/foreign_cc_test/BUILD.bazel
+++ b/tests/foreign_cc_test/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 sh_test(
     name = "get_nasm_tool_test",
     size = "small",
+    srcs = ["get_nasm_tool_test.sh"],
+    data = ["@rules_nasm//nasm:assembler"],
     env = {"NASM": "$(rootpath @rules_nasm//nasm:assembler)"},
-    srcs = ["get_nasm_tool_test.sh",],
-    data = ["@rules_nasm//nasm:assembler"]
 )


### PR DESCRIPTION
This also includes auto-fixes like the direct use of [rules_shell](https://github.com/bazelbuild/rules_shell) and migrations from `native.cc_*` to loaded rules from [rules_cc](https://github.com/bazelbuild/rules_cc).