### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,11 +15,11 @@ jobs:
       - uses: actions/checkout@master
       - name: Run tests
         run: bazel
-          --bazelrc=${{ github.workspace }}/ci.bazelrc
+          --bazelrc=${{ github.workspace }}/.github/ci.bazelrc
           run
           --compilation_mode=opt --stamp
-          //docs:publish_book
           --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
+          //docs:publish_book
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.7
         with:


### PR DESCRIPTION
This was a miss from https://github.com/morganwl/rules_nasm/pull/54 which occurred due to something about pull-requests not playing well with buildbuddy (seemingly a permissions issue) and the full impact of the change not being verifiable before merge. Docs should once again be published after this change.