### PR TITLE
Update CI to use disk cache vs buildbuddy

### DIFF
--- a/.github/ci.bazelrc
+++ b/.github/ci.bazelrc
@@ -1,5 +1,7 @@
 # use BuildBuddy for remote cache
-build --bes_results_url=https://rules-nasm.buildbuddy.io/invocation/
-build --bes_backend=grpcs://rules-nasm.buildbuddy.io
-build --remote_cache=grpcs://rules-nasm.buildbuddy.io
-build --remote_timeout=10m
+build:buildbuddy --bes_results_url=https://rules-nasm.buildbuddy.io/invocation/
+build:buildbuddy --bes_backend=grpcs://rules-nasm.buildbuddy.io
+build:buildbuddy --remote_cache=grpcs://rules-nasm.buildbuddy.io
+build:buildbuddy --remote_timeout=10m
+
+build --keep_going

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,12 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          disk-cache: true
+          bazelisk-cache: true
+          repository-cache: true
       - name: Run tests
         run: bazel
           --bazelrc=${{ github.workspace }}/.github/ci.bazelrc
           run
           --compilation_mode=opt --stamp
-          --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
           //docs:publish_book
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.7

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,35 +11,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, "windows-2022"]
-        bazel_version: [7.3.2, latest]
+        os: [ubuntu-24.04, macos-13, windows-2022]
+        bazel_version: [7.x, 8.x, latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: 'read'
       packages: 'read'
       id-token: 'write'
     steps:
-      - uses: bazel-contrib/setup-bazel@0.14.0
+      - uses: bazel-contrib/setup-bazel@0.15.0
         with:
+          disk-cache: true
           bazelisk-cache: true
+          repository-cache: true
       - uses: actions/checkout@v4
       - name: Unit tests
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run:
           bazel
           --bazelrc=${{ github.workspace }}/.github/ci.bazelrc
           test //...
-          --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
       - name: e2e tests
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run:
           e2e/test.sh
           --bazelrc=${{ github.workspace }}/.github/ci.bazelrc
-          --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I'm seeing the following in other PRs:
```
 WARNING: Uploading BEP referenced local file: UNAUTHENTICATED: missing API key
 ```
 
 It seems like https://github.com/bazel-contrib/setup-bazel supports a disk cache which might be able to provide the same speed/caching benefits that buildbuddy does.