### PR TITLE
Add use_default_shell_env to nasm_assemble

### DIFF
--- a/nasm/private/rules/library.bzl
+++ b/nasm/private/rules/library.bzl
@@ -82,6 +82,7 @@ def nasm_assemble(
         inputs = inputs,
         outputs = [out],
         tools = nasm_toolchain.all_files,
+        use_default_shell_env = True,
     )
 
     return out


### PR DESCRIPTION
Otherwise, when using a "heremetic" MSVC compiler to build nasm.exe--that is, one carefully installed in it's own directory without installing runtime libraries in the system--the build binary may not find the proper MSVC runtime library dlls, which can result in an error like (Exit -1073741515) as shown below.

Note that this is really only required on windows since there is no -rpath equivalent for linking against dlls.
See: https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order
And: https://devblogs.microsoft.com/oldnewthing/20170126-00/?p=95265

```
# Execution platform: @@internal_platforms_do_not_use//host:host
(04:02:41) ERROR: T:/_out/external/org_videolan_dav1d/BUILD.bazel:176:16: NasmAssemble external/org_videolan_dav1d/_obj/dav1d_asm_x86_asm/cdef16_avx512.asm.obj failed: (Exit -1073741515): nasm.exe failed: error executing NasmAssemble command (from target @@org_videolan_dav1d//:dav1d_asm_x86_asm) 
  cd /d T:/_out/execroot/tensorstore
bazel-out\x64_windows-dbg-exec-ST-a828a81199fe\bin\external\nasm\nasm.exe -fwin64 -I external/org_videolan_dav1d/ -I bazel-out/x64_windows-dbg/bin/external/org_videolan_dav1d/ -I external/org_videolan_dav1d/src/ -I bazel-out/x64_windows-dbg/bin/external/org_videolan_dav1d/src/ -I external/org_videolan_dav1d/build/ -I bazel-out/x64_windows-dbg/bin/external/org_videolan_dav1d/build/ -I external/org_videolan_dav1d/src/x86/ -s -w-macro-params-legacy -w-orphan-labels -o bazel-out/x64_windows-dbg/bin/external/org_videolan_dav1d/_obj/dav1d_asm_x86_asm/cdef16_avx512.asm.obj external/org_videolan_dav1d/src/x86/cdef16_avx512.asm
# Configuration: cada574801dbff18715fef3a2297599a6fb966b4492b3e74a90266dc6fc0607a
```
